### PR TITLE
Adding configuration features to allow disabling of some c2d features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ keywords = ["iot", "azure"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+default = ["c2d-messages", "direct-methods", "twin-properties"]
+direct-methods = []
+twin-properties = []
+c2d-messages = []
+
 [dependencies]
 native-tls = "0.2.4"
 mqtt-protocol = { version = "0.8.1", features = ["async"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,24 @@
 //! Azure IoT device client for writing iot device code in rust
 //!
+//! ## Feature flags
+//!
+//! SDK client uses [feature
+//! flags](https://doc.rust-lang.org/cargo/reference/features.html#the-features-section) to
+//! configure capabilities of the client sdk. By default all features are enabled.
+//!
+//! Device to cloud messaging is always available.
+//!
+//! - `c2d-messages`: Enables cloud to device messaging
+//! - `twin-properties`: Enables device twin property updates
+//! - `direct-methods`: Enables listening for direct method invocations
+//!
+//! ### Disabling capabilities
+//! If not all features are required, disable the default features and add only desired.
+//!
+//! ```toml
+//! azure_iot_sdk = { version = "0.2.0", features = [], default-features = false }
+//! ```
+//!
 //! # Examples
 //!
 //! A simple client


### PR DESCRIPTION
Disabling the initial receiving tasks for #12 

Would like to also add `cfg` compilation filters still to enum cases so the types that aren't enabled aren't event usable from code to avoid confusion if functionality is coded but not working because it's disabled