### PR TITLE
Refactor send and receive for MQTT

### DIFF
--- a/examples/receive-c2d-messages.rs
+++ b/examples/receive-c2d-messages.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, MqttTransport};
+use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, MessageType, MqttTransport};
 
 use serde::Deserialize;
 
@@ -38,14 +38,11 @@ async fn main() {
 
     info!("Initialized client");
 
-    client
-        .on_message(|msg| {
-            println!(
-                "Received message '{}'",
-                std::str::from_utf8(&msg.body).unwrap()
-            );
-        })
-        .await;
-
-    std::thread::park();
+    let mut recv = client.get_receiver().await;
+    while let Some(msg) = recv.recv().await {
+        match msg {
+            MessageType::C2DMessage(msg) => info!("Received message {:?}", msg),
+            _ => {}
+        }
+    }
 }

--- a/examples/temperature-client.rs
+++ b/examples/temperature-client.rs
@@ -120,30 +120,6 @@ async fn main() {
         }
     };
 
-    // let mut rx = client.get_receiver().unwrap();
-    // let mut tx = client.sender();
-    // let receiver = async move {
-    //     while let Some(msg) = rx.recv().await {
-    //         match msg {
-    //             MessageType::C2DMessage(message) => info!("Received message {:?}", message),
-    //             MessageType::DirectMethod(direct_method) => {
-    //                 info!("Received direct method {:?}", direct_method);
-    //                 tx.send(SendType::RespondToDirectMethod(DirectMethodResponse::new(
-    //                     direct_method.request_id,
-    //                     0,
-    //                     Some("{'responseKey': 1}".into()),
-    //                 )))
-    //                 .await
-    //                 .unwrap();
-    //             }
-    //             MessageType::DesiredPropertyUpdate(property_update) => {
-    //                 let json: serde_json::Value = property_update.into();
-    //                 info!("Received property update {:?}", json);
-    //             }
-    //         }
-    //     }
-    // };
-
     let mut interval = time::interval(time::Duration::from_secs(2));
     let mut count = 0u32;
     let sensor = TemperatureSensor::default();

--- a/examples/temperature-client.rs
+++ b/examples/temperature-client.rs
@@ -106,7 +106,6 @@ async fn main() {
                 method_name,
                 std::str::from_utf8(&msg.body).unwrap()
             );
-            0
         })
         .await;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,7 +11,7 @@ pub enum MessageType {
     /// Cloud updating desired properties
     DesiredPropertyUpdate(Message),
     /// Cloud sending a direct method invocation
-    DirectMethod(DirectMethodInvokation),
+    DirectMethod(DirectMethodInvocation),
 }
 
 /// Instance to respond to a direct method invocation
@@ -122,8 +122,8 @@ impl MessageBuilder {
 
 /// Details about a cloud to device direct method invocation call
 #[derive(Debug)]
-pub struct DirectMethodInvokation {
-    pub(crate) method_name: String,
-    pub(crate) message: Message,
-    pub(crate) request_id: String,
+pub struct DirectMethodInvocation {
+    pub method_name: String,
+    pub message: Message,
+    pub request_id: String,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
 
-use mqtt::QualityOfService;
-use mqtt::TopicFilter;
-
 /// Type of message received in cloud to device communication
 #[derive(Debug)]
 pub enum MessageType {
@@ -31,28 +28,6 @@ impl DirectMethodResponse {
             body: body.unwrap_or_default(),
         }
     }
-}
-
-/// The type of message to send for device to cloud communication
-#[derive(Debug)]
-pub enum SendType {
-    /// Send a device to cloud message
-    Message(Message),
-    /// Ping for keep alive
-    Ping,
-    /// Respond to a direct method invocation
-    RespondToDirectMethod(DirectMethodResponse),
-    /// Request current twin properties from hub
-    RequestTwinProperties(String),
-    /// Subscribe to a particular topic
-    Subscribe(Vec<(TopicFilter, QualityOfService)>),
-    /// Update the current properties to the hub
-    PublishTwinProperties {
-        ///
-        request_id: String,
-        ///
-        body: String,
-    },
 }
 
 // System properties that are user settable

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -102,7 +102,7 @@ pub(crate) async fn receive<S>(
     let rx_topic_prefix = device_bound_messages_topic_prefix(&device_id);
     let mut message_handler: Option<Box<dyn Fn(Message) + Send>> = None;
     let mut twin_handler: Option<Box<dyn Fn(Message) + Send>> = None;
-    let mut method_handler: Option<Box<dyn Fn(String, Message) -> i32 + Send>> = None;
+    let mut method_handler: Option<Box<dyn Fn(String, Message) + Send>> = None;
 
     loop {
         tokio::select! {
@@ -160,16 +160,9 @@ pub(crate) async fn receive<S>(
 
                         let method_components: Vec<_> = details.split('/').collect();
 
-                        // If we don't have a handler respond with -1
-                        let mut method_response = -1;
-
                         if let Some(method_handler) = &method_handler {
-                          method_response = method_handler(method_components[0].to_string(), message);
+                          method_handler(method_components[0].to_string(), message);
                         }
-
-                        let request_id = method_components[1][REQUEST_ID_PARAM.len()..].to_string();
-                        let to_respond_with = SendType::RespondToDirectMethod(DirectMethodResponse::new(request_id, method_response, None));
-                        // sender.send(to_respond_with).await.unwrap();
                     }
                 }
                 _ => {}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -33,5 +33,5 @@ pub enum MessageHandler {
     ///
     TwinUpdate(Box<dyn Fn(Message) + Send>),
     ///
-    DirectMethod(Box<dyn Fn(String, Message) -> i32 + Send>),
+    DirectMethod(Box<dyn Fn(String, Message) + Send>),
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,4 +1,4 @@
-use crate::{message::Message, token::TokenSource};
+use crate::{message::Message, token::TokenSource, DirectMethodResponse};
 use async_trait::async_trait;
 
 ///
@@ -14,6 +14,15 @@ pub trait Transport {
     async fn send_property_update(&mut self, request_id: &str, body: &str);
     ///
     async fn set_message_handler(&mut self, device_id: &str, handler: MessageHandler);
+
+    ///
+    async fn request_twin_properties(&mut self, request_id: &str);
+
+    ///
+    async fn respond_to_direct_method(&mut self, response: DirectMethodResponse);
+
+    ///
+    async fn ping(&mut self);
 }
 
 ///

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,5 +1,6 @@
-use crate::{message::Message, token::TokenSource, DirectMethodResponse};
+use crate::{message::Message, token::TokenSource, DirectMethodResponse, MessageType};
 use async_trait::async_trait;
+use tokio::sync::mpsc::Receiver;
 
 ///
 #[async_trait]
@@ -12,8 +13,6 @@ pub trait Transport {
     async fn send_message(&mut self, message: Message);
     ///
     async fn send_property_update(&mut self, request_id: &str, body: &str);
-    ///
-    async fn set_message_handler(&mut self, device_id: &str, handler: MessageHandler);
 
     ///
     async fn request_twin_properties(&mut self, request_id: &str);
@@ -23,15 +22,6 @@ pub trait Transport {
 
     ///
     async fn ping(&mut self);
-}
 
-///
-// #[derive(Debug)]
-pub enum MessageHandler {
-    ///
-    Message(Box<dyn Fn(Message) + Send>),
-    ///
-    TwinUpdate(Box<dyn Fn(Message) + Send>),
-    ///
-    DirectMethod(Box<dyn Fn(String, Message) + Send>),
+    async fn get_receiver(&mut self) -> Receiver<MessageType>;
 }


### PR DESCRIPTION
Makes receiving a bit more 'rust like' using an mpsc Receiver. And inlines the sending functions so there isn't a second global async loop