### PR TITLE
Enable routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "config",
  "dotenv",
  "env_logger",
+ "form_urlencoded",
  "futures",
  "hmac",
  "hyper",
@@ -63,7 +64,6 @@ dependencies = [
  "log",
  "mqtt-protocol",
  "native-tls",
- "percent-encoding",
  "rand",
  "rand_distr",
  "serde 1.0.106",
@@ -251,6 +251,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fuchsia-zircon"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "log",
  "mqtt-protocol",
  "native-tls",
+ "percent-encoding",
  "rand",
  "rand_distr",
  "serde 1.0.106",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ base64 = "0.12.0"
 async-trait = "0.1.30"
 hyper = { version = "0.13", optional = true }
 hyper-tls = { version = "0.4.1", optional = true }
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 log = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ base64 = "0.12.0"
 async-trait = "0.1.30"
 hyper = { version = "0.13", optional = true }
 hyper-tls = { version = "0.4.1", optional = true }
-percent-encoding = "2.1.0"
+form_urlencoded = "1.0.0"
 
 [dev-dependencies]
 log = "0.4.0"

--- a/src/message.rs
+++ b/src/message.rs
@@ -89,6 +89,22 @@ impl MessageBuilder {
         self
     }
 
+    /// Set the contentType for this message, such as `text/plain`.
+    /// To allow routing query on the message body, this value should be set to `application/json`
+    pub fn set_content_type(mut self, content_type: String) -> Self {
+        self.system_properties
+            .insert("contentType".to_owned(), content_type);
+        self
+    }
+
+    /// Set the contentEncoding for this message.
+    /// If the contentType is set to `application/json`, allowed values are `UTF-8`, `UTF-16`, `UTF-32`.
+    pub fn set_content_encoding(mut self, content_encoding: String) -> Self {
+        self.system_properties
+            .insert("contentEncoding".to_owned(), content_encoding);
+        self
+    }
+
     /// Add a message property
     pub fn add_message_property(mut self, key: String, value: String) -> Self {
         self.properties.insert(key, value);
@@ -115,4 +131,32 @@ pub struct DirectMethodInvocation {
     pub message: Message,
     ///
     pub request_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_setting_content_type() {
+        let builder = Message::builder();
+        let msg = builder
+            .set_content_type("application/json".to_owned())
+            .set_body(vec![])
+            .build();
+
+        assert_eq!(msg.system_properties["contentType"], "application/json");
+    }
+
+    #[test]
+    fn test_setting_content_encoding() {
+        let builder = Message::builder();
+        let msg = builder
+            .set_content_type("application/json".to_owned())
+            .set_content_encoding("UTF-8".to_owned())
+            .set_body(vec![])
+            .build();
+
+        assert_eq!(msg.system_properties["contentEncoding"], "UTF-8");
+    }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -40,12 +40,6 @@ impl DirectMethodResponse {
     }
 }
 
-// System properties that are user settable
-// https://docs.microsoft.com/bs-cyrl-ba/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages
-pub(crate) const MESSAGE_ID: &str = "message-id";
-pub(crate) const CONTENT_TYPE: &str = "content-type";
-pub(crate) const CONTENT_ENCODING: &str = "content-encoding";
-
 /// Message used in body of communication
 #[derive(Default, Debug)]
 pub struct Message {
@@ -86,21 +80,27 @@ impl MessageBuilder {
 
     /// Set the identifier for this message
     pub fn set_message_id(self, message_id: String) -> Self {
-        self.set_system_property(MESSAGE_ID, message_id)
+        self.set_system_property("$.mid", message_id)
     }
 
     /// Set the content-type for this message, such as `text/plain`.
     /// To allow routing query on the message body, this value should be set to `application/json`
     pub fn set_content_type(self, content_type: String) -> Self {
-        self.set_system_property(CONTENT_TYPE, content_type)
+        self.set_system_property("$.ct", content_type)
     }
 
     /// Set the content-encoding for this message.
     /// If the content-type is set to `application/json`, allowed values are `UTF-8`, `UTF-16`, `UTF-32`.
     pub fn set_content_encoding(self, content_encoding: String) -> Self {
-        self.set_system_property(CONTENT_ENCODING, content_encoding)
+        self.set_system_property("$.ce", content_encoding)
     }
 
+    /// System properties that are user settable
+    /// https://docs.microsoft.com/bs-cyrl-ba/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages
+    /// The full list of valid "wire ids" is availabe here:
+    /// https://github.com/Azure/azure-iot-sdk-csharp/blob/67f8c75576edfcbc20e23a01afc88be47552e58c/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1068-L1086
+    /// If you need to add support for a new property,
+    /// you should create a new public function that sets the appropriate wire id.
     fn set_system_property(mut self, property_name: &str, value: String) -> Self {
         self.system_properties
             .insert(property_name.to_owned(), value);
@@ -147,7 +147,7 @@ mod tests {
             .set_body(vec![])
             .build();
 
-        assert_eq!(msg.system_properties[CONTENT_TYPE], "application/json");
+        assert_eq!(msg.system_properties["$.ct"], "application/json");
     }
 
     #[test]
@@ -159,6 +159,6 @@ mod tests {
             .set_body(vec![])
             .build();
 
-        assert_eq!(msg.system_properties[CONTENT_ENCODING], "UTF-8");
+        assert_eq!(msg.system_properties["$.ce"], "UTF-8");
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -43,6 +43,8 @@ impl DirectMethodResponse {
 // System properties that are user settable
 // https://docs.microsoft.com/bs-cyrl-ba/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages
 pub(crate) const MESSAGE_ID: &str = "message-id";
+pub(crate) const CONTENT_TYPE: &str = "content-type";
+pub(crate) const CONTENT_ENCODING: &str = "content-encoding";
 
 /// Message used in body of communication
 #[derive(Default, Debug)]
@@ -83,25 +85,25 @@ impl MessageBuilder {
     }
 
     /// Set the identifier for this message
-    pub fn set_message_id(mut self, message_id: String) -> Self {
-        self.system_properties
-            .insert(MESSAGE_ID.to_owned(), message_id);
-        self
+    pub fn set_message_id(self, message_id: String) -> Self {
+        self.set_system_property(MESSAGE_ID, message_id)
     }
 
-    /// Set the contentType for this message, such as `text/plain`.
+    /// Set the content-type for this message, such as `text/plain`.
     /// To allow routing query on the message body, this value should be set to `application/json`
-    pub fn set_content_type(mut self, content_type: String) -> Self {
-        self.system_properties
-            .insert("contentType".to_owned(), content_type);
-        self
+    pub fn set_content_type(self, content_type: String) -> Self {
+        self.set_system_property(CONTENT_TYPE, content_type)
     }
 
-    /// Set the contentEncoding for this message.
-    /// If the contentType is set to `application/json`, allowed values are `UTF-8`, `UTF-16`, `UTF-32`.
-    pub fn set_content_encoding(mut self, content_encoding: String) -> Self {
+    /// Set the content-encoding for this message.
+    /// If the content-type is set to `application/json`, allowed values are `UTF-8`, `UTF-16`, `UTF-32`.
+    pub fn set_content_encoding(self, content_encoding: String) -> Self {
+        self.set_system_property(CONTENT_ENCODING, content_encoding)
+    }
+
+    fn set_system_property(mut self, property_name: &str, value: String) -> Self {
         self.system_properties
-            .insert("contentEncoding".to_owned(), content_encoding);
+            .insert(property_name.to_owned(), value);
         self
     }
 
@@ -145,7 +147,7 @@ mod tests {
             .set_body(vec![])
             .build();
 
-        assert_eq!(msg.system_properties["contentType"], "application/json");
+        assert_eq!(msg.system_properties[CONTENT_TYPE], "application/json");
     }
 
     #[test]
@@ -157,6 +159,6 @@ mod tests {
             .set_body(vec![])
             .build();
 
-        assert_eq!(msg.system_properties["contentEncoding"], "UTF-8");
+        assert_eq!(msg.system_properties[CONTENT_ENCODING], "UTF-8");
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -42,7 +42,7 @@ impl DirectMethodResponse {
 
 // System properties that are user settable
 // https://docs.microsoft.com/bs-cyrl-ba/azure/iot-hub/iot-hub-devguide-messages-construct#system-properties-of-d2c-iot-hub-messages
-const MESSAGE_ID: &str = "message-id";
+pub(crate) const MESSAGE_ID: &str = "message-id";
 
 /// Message used in body of communication
 #[derive(Default, Debug)]

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -199,7 +199,6 @@ impl Transport for MqttTransport {
     }
 
     async fn send_message(&mut self, message: Message) {
-        // TODO: Append properties and system properties to topic path
         let full_topic = build_topic_name(&self.d2c_topic, &message).unwrap();
         trace!("Sending message {:?} to topic {:?}", message, full_topic);
         let publish_packet =

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -513,9 +513,6 @@ fn build_topic_name(
     base_topic: &TopicName,
     message: &Message,
 ) -> Result<TopicName, TopicNameError> {
-    let mut raw_name = base_topic.to_string();
-    let mut is_first = true;
-
     //BTree for deterministic ordering
     let mut props = std::collections::BTreeMap::new();
     for (key, val) in message.system_properties.iter() {
@@ -525,6 +522,8 @@ fn build_topic_name(
         props.insert(key, val);
     }
 
+    let mut raw_name = base_topic.to_string();
+    let mut is_first = true;
     for (key, val) in props.iter() {
         if !is_first {
             raw_name.push('&');

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -521,7 +521,6 @@ fn build_topic_name(
     for (key, val) in message.system_properties.iter() {
         props.insert(system_name_to_wire_name(key), val);
     }
-    // intentionally overwrite any duplicate keys, same behavior as official MS lib
     for (key, val) in message.properties.iter() {
         props.insert(key, val);
     }

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -489,6 +489,11 @@ impl MqttTransport {
 }
 
 fn system_name_to_wire_name(system_name: &str) -> &str {
+    /*
+     * This is currently the bare minimum to support routing, plus the message id.
+     * The full list of "wire ids" is availabe here:
+     * https://github.com/Azure/azure-iot-sdk-csharp/blob/67f8c75576edfcbc20e23a01afc88be47552e58c/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1068-L1086
+     */
     use crate::message;
     match system_name {
         message::CONTENT_TYPE => "$.ct",

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -488,21 +488,6 @@ impl MqttTransport {
     }
 }
 
-fn system_name_to_wire_name(system_name: &str) -> &str {
-    /*
-     * This is currently the bare minimum to support routing, plus the message id.
-     * The full list of "wire ids" is availabe here:
-     * https://github.com/Azure/azure-iot-sdk-csharp/blob/67f8c75576edfcbc20e23a01afc88be47552e58c/iothub/device/src/Transport/Mqtt/MqttIotHubAdapter.cs#L1068-L1086
-     */
-    use crate::message;
-    match system_name {
-        message::CONTENT_TYPE => "$.ct",
-        message::CONTENT_ENCODING => "$.ce",
-        message::MESSAGE_ID => "$.mid",
-        _ => panic!("Invalid system property name"),
-    }
-}
-
 fn url_encode(value: &str) -> String {
     use percent_encoding::{AsciiSet, NON_ALPHANUMERIC};
     const ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-');
@@ -516,7 +501,7 @@ fn build_topic_name(
     //BTree for deterministic ordering
     let mut props = std::collections::BTreeMap::new();
     for (key, val) in message.system_properties.iter() {
-        props.insert(system_name_to_wire_name(key), val);
+        props.insert(key, val);
     }
     for (key, val) in message.properties.iter() {
         props.insert(key, val);


### PR DESCRIPTION
This enables the ability to perform routing based on the message body.
https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-routing-query-syntax#message-routing-query-based-on-message-body

Fixes #31 