### PR TITLE
Add Error handling and forwarding for the receive message.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["c2d-messages", "direct-methods", "twin-properties", "with-provision"]
+default = ["c2d-messages", "direct-methods", "twin-properties", "with-provision", "error-handling-messages"]
 direct-methods = []
 twin-properties = []
 c2d-messages = []
+error-handling-messages = []
 http-transport = ["hyper", "hyper-tls"]
 with-provision = ["hyper", "hyper-tls"]
 

--- a/examples/temperature-client.rs
+++ b/examples/temperature-client.rs
@@ -116,6 +116,9 @@ async fn main() -> azure_iot_sdk::Result<()> {
                     MessageType::DesiredPropertyUpdate(msg) => {
                         info!("Desired properties updated {:?}", msg)
                     }
+                    MessageType::ErrorReceive(err) => {
+                        error!("Error during receive {:?}", err)
+                    }
                 }
             }
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
+#[cfg(feature = "error-handling-messages")]
+use mqtt::packet::VariablePacketError;
 
 /// Type of message received in cloud to device communication
 #[cfg(any(
     feature = "direct-methods",
     feature = "c2d-messages",
-    feature = "twin-properties"
+    feature = "twin-properties",
+    feature = "error-handling-messages",
 ))]
 #[derive(Debug)]
 pub enum MessageType {
@@ -17,6 +20,9 @@ pub enum MessageType {
     /// Cloud sending a direct method invocation
     #[cfg(feature = "direct-methods")]
     DirectMethod(DirectMethodInvocation),
+    /// Error occurred in the message loop
+    #[cfg(feature = "error-handling-messages")]
+    ErrorReceive(VariablePacketError)
 }
 
 /// Instance to respond to a direct method invocation


### PR DESCRIPTION
Hi,

The current message send loop for MQTT just spins forever if you, e.g., block the device in Azure.  So I think the following makes sense?  Gives the user a chance to react to a message error (or ignore).  Not sure.

Samit