### PR TITLE
Remove need to define transport in generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ direct-methods = []
 twin-properties = []
 c2d-messages = []
 error-handling-messages = []
-http-transport = ["hyper", "hyper-tls", "tokio-compat-02"]
+# http-transport = ["hyper", "hyper-tls", "tokio-compat-02"]
 with-provision = ["hyper", "hyper-tls", "tokio-compat-02"]
 
 [dependencies]

--- a/examples/receive-c2d-messages.rs
+++ b/examples/receive-c2d-messages.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, MessageType, MqttTransport};
+use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, MessageType};
 
 use serde::Deserialize;
 
@@ -33,12 +33,8 @@ async fn main() -> azure_iot_sdk::Result<()> {
     )
     .unwrap();
 
-    let mut client = IoTHubClient::<MqttTransport>::new(
-        &config.hostname,
-        config.device_id.clone(),
-        token_source,
-    )
-    .await?;
+    let mut client =
+        IoTHubClient::new(&config.hostname, config.device_id.clone(), token_source).await?;
 
     info!("Initialized client");
 

--- a/examples/send-message.rs
+++ b/examples/send-message.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, Message, MqttTransport};
+use azure_iot_sdk::{DeviceKeyTokenSource, IoTHubClient, Message};
 
 use serde::Deserialize;
 
@@ -33,12 +33,8 @@ async fn main() -> azure_iot_sdk::Result<()> {
     )
     .unwrap();
 
-    let mut client = IoTHubClient::<MqttTransport>::new(
-        &config.hostname,
-        config.device_id.clone(),
-        token_source,
-    )
-    .await?;
+    let mut client =
+        IoTHubClient::new(&config.hostname, config.device_id.clone(), token_source).await?;
 
     info!("Initialized client");
 

--- a/examples/temperature-client.rs
+++ b/examples/temperature-client.rs
@@ -2,7 +2,7 @@
 extern crate log;
 
 use azure_iot_sdk::{
-    DeviceKeyTokenSource, DirectMethodResponse, IoTHubClient, Message, MessageType, MqttTransport,
+    DeviceKeyTokenSource, DirectMethodResponse, IoTHubClient, Message, MessageType,
 };
 
 use chrono::{DateTime, Utc};
@@ -90,12 +90,8 @@ async fn main() -> azure_iot_sdk::Result<()> {
     )
     .unwrap();
 
-    let mut client = IoTHubClient::<MqttTransport>::new(
-        &config.hostname,
-        config.device_id.clone(),
-        token_source,
-    )
-    .await?;
+    let mut client =
+        IoTHubClient::new(&config.hostname, config.device_id.clone(), token_source).await?;
 
     info!("Initialized client");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -61,11 +61,6 @@ impl IoTHubClient {
         TS: TokenSource + Sync + Send,
     {
         let transport = ClientTransport::new(hub_name, device_id.clone(), token_source).await?;
-        //         #[cfg(not(any(feature = "http-transport", feature = "amqp-transport")))]
-        //         let transport = MqttTransport::new(hub_name, device_id, token_source).await;
-        //
-        //         #[cfg(feature = "http-transport")]
-        //         let transport = HttpTransport::new(hub_name, device_id, token_source).await;
 
         Ok(Self {
             device_id,

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ impl IoTHubClient {
     ///
     /// # Example
     /// ```no_run
-    /// use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource, MqttTransport};
+    /// use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource};
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -78,7 +78,7 @@ impl IoTHubClient {
     /// # Example
     /// ```no_run
     /// use tokio::time;
-    /// use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource, MqttTransport, Message};
+    /// use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource, Message};
     ///
     /// #[tokio::main]
     /// async fn main() -> azure_iot_sdk::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! A simple client
 //! ```no_run
 //! use tokio::time;
-//! use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource, MqttTransport, Message};
+//! use azure_iot_sdk::{IoTHubClient, DeviceKeyTokenSource, Message};
 //!
 //! #[tokio::main]
 //! async fn main() -> azure_iot_sdk::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!     ).unwrap();
 //!
 //!     let mut client =
-//!         IoTHubClient::<MqttTransport>::new(iothub_hostname, device_id.into(), token_source).await?;
+//!         IoTHubClient::new(iothub_hostname, device_id.into(), token_source).await?;
 //!
 //!     let mut interval = time::interval(time::Duration::from_secs(1));
 //!     let mut count: u32 = 0;
@@ -71,16 +71,14 @@ pub const SDK_VERSION: &str = std::env!("CARGO_PKG_VERSION");
 pub mod client;
 pub use client::*;
 
-#[cfg(feature = "http-transport")]
-pub(crate) mod http_transport;
+// #[cfg(feature = "http-transport")]
+// pub(crate) mod http_transport;
 /// Message types for communicating with the IoT Hub
 pub mod message;
 pub use message::*;
 ///
-// #[cfg(not(any(feature = "http-transport", feature = "amqp-transport")))]
-pub mod mqtt_transport;
-// #[cfg(not(any(feature = "http-transport", feature = "amqp-transport")))]
-pub use mqtt_transport::*;
+#[cfg(not(feature = "http-transport"))]
+pub(crate) mod mqtt_transport;
 ///
 pub mod token;
 pub use token::*;

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -126,7 +126,7 @@ async fn tcp_connect(iot_hub: &str) -> crate::Result<TlsStream<TcpStream>> {
 
 ///
 #[derive(Debug, Clone)]
-pub struct MqttTransport {
+pub(crate) struct MqttTransport {
     write_socket: Arc<Mutex<WriteHalf<TlsStream<TcpStream>>>>,
     read_socket: Arc<Mutex<ReadHalf<TlsStream<TcpStream>>>>,
     d2c_topic: TopicName,

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -6,7 +6,6 @@ use serde::export::Formatter;
 use crate::{
     client::IoTHubClient,
     token::{generate_token, DeviceKeyTokenSource},
-    transport::Transport,
 };
 
 const DPS_HOST: &str = "https://global.azure-devices-provisioning.net";
@@ -166,10 +165,7 @@ pub async fn get_iothub_from_provision_service(
     Ok(hubname)
 }
 
-impl<TR> IoTHubClient<TR>
-where
-    TR: Transport<TR>,
-{
+impl IoTHubClient {
     /// Create a new IoT Hub device client using the device provisioning service
     ///
     /// # Arguments
@@ -188,7 +184,7 @@ where
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut client = IoTHubClient::<MqttTransport>::from_provision_service(
+    ///     let mut client = IoTHubClient::from_provision_service(
     ///           "ScopeID",
     ///           "DeviceID".into(),
     ///           "DeviceKey",
@@ -201,7 +197,7 @@ where
         device_id: String,
         device_key: &str,
         max_retries: i32,
-    ) -> Result<IoTHubClient<TR>, Box<dyn std::error::Error>> {
+    ) -> Result<IoTHubClient, Box<dyn std::error::Error>> {
         use tokio_compat_02::FutureExt;
         // Note - the call to .compat() can be removed in the future when hyper is
         // tokio 0.3 compliant.

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -180,7 +180,7 @@ impl IoTHubClient {
     ///
     /// # Example
     /// ```no_run
-    /// use azure_iot_sdk::{IoTHubClient, MqttTransport};
+    /// use azure_iot_sdk::IoTHubClient;
     ///
     /// #[tokio::main]
     /// async fn main() {

--- a/src/token.rs
+++ b/src/token.rs
@@ -123,6 +123,20 @@ impl<'a> TokenSource for DeviceKeyTokenSource<'_> {
     }
 }
 
+/// Useful if you need to customize the user name and password sent to Azure (for example
+/// to implement an IoT Plug-n-Play device))
+#[derive(Debug, Clone)]
+pub struct UsernamePasswordTokenSource {
+    username: String,
+    password: String,
+}
+
+impl TokenSource for UsernamePasswordTokenSource {
+    fn get(&self, _expiry: &DateTime<Utc>) -> String {
+        self.password.clone()
+    }
+}
+
 pub(crate) fn generate_token(key: &str, message: &str) -> String {
     // Checked base64 and hmac in new so should be safe to unwrap here
     let key = base64::decode(&key).unwrap();


### PR DESCRIPTION
Purpose here is to clean up how a developer creates an client from `IoTHubClient::<MqttTransport>::new` to `IoTHubClient::new`

- Make MqttTransport private to crate
- Removed `new_with_transport` as it leaked the transport types but shifted functionality into `UsernamePasswordTokenSource` which I think provides the same functionality