### PR TITLE
Spawning ping task to help client keep alive

### DIFF
--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -20,7 +20,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::{channel, Receiver};
 use tokio::sync::Mutex;
 use tokio_native_tls::{TlsConnector, TlsStream};
-use tokio::time;
+use tokio::{time, task::JoinHandle};
 
 use async_trait::async_trait;
 
@@ -179,7 +179,7 @@ pub(crate) struct MqttTransport {
     device_id: String,
     #[cfg(feature = "c2d-messages")]
     rx_topic_prefix: String,
-    ping_join_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
+    ping_join_handle: Option<Arc<JoinHandle<()>>>,
     // rx_loop_handle: Option<AbortHandle>,
 }
 
@@ -232,7 +232,7 @@ impl MqttTransport {
     }
 
     ///
-    fn ping_on_secs_interval(&self, ping_interval: u8) -> tokio::task::JoinHandle<()> {
+    fn ping_on_secs_interval(&self, ping_interval: u8) -> JoinHandle<()> {
         let mut ping_interval = time::interval(time::Duration::from_secs(ping_interval.into()));
         let mut cloned_self = self.clone();
         tokio::spawn(async move {

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -185,11 +185,11 @@ pub(crate) struct MqttTransport {
 
 impl Drop for MqttTransport {
     fn drop(&mut self) {
-        // if let Some(recv_abort_handle) = &self.rx_loop_handle {
-        //     recv_abort_handle.abort();
-        // }
-        if let Some(ping_join_handle) = &self.ping_join_handle {
-            ping_join_handle.abort();
+        // Check to see whether we're the last instance holding the Arc and only abort the ping if so
+        if let Some(handle) = self.ping_join_handle.take() {
+            if let Ok(handle) = Arc::try_unwrap(handle) {
+                handle.abort();
+            }
         }
     }
 }


### PR DESCRIPTION
First step to help with #50 to ensure that the TCP connection stays open by ensuring client keeps a ping request and response happening