### PR TITLE
mqtt: Change logging level of ping, and increase ping interval to every 8 seconds

### DIFF
--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -225,7 +225,7 @@ impl MqttTransport {
             // rx_loop_handle: None,
         };
 
-        mqtt_transport.ping_join_handle = Some(Arc::new(mqtt_transport.ping_on_secs_interval(15)));
+        mqtt_transport.ping_join_handle = Some(Arc::new(mqtt_transport.ping_on_secs_interval(8)));
 
         Ok(mqtt_transport)
     }

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -327,7 +327,7 @@ impl Transport for MqttTransport {
     }
 
     async fn ping(&mut self) -> crate::Result<()> {
-        info!("Sending PINGREQ to broker");
+        debug!("Sending PINGREQ to broker");
 
         let pingreq_packet = PingreqPacket::new();
 
@@ -376,7 +376,7 @@ impl Transport for MqttTransport {
                 match packet {
                     // TODO: handle ping req from server and we should send ping response in return
                     VariablePacket::PingrespPacket(..) => {
-                        info!("Receiving PINGRESP from broker ..");
+                        debug!("Receiving PINGRESP from broker ..");
                     }
                     VariablePacket::PublishPacket(ref publ) => {
                         let mut message = Message::new(publ.payload().to_vec());


### PR DESCRIPTION
First off, thanks for a neat library! It solved exactly my use-case (I had to extend it a little bit), but it works great! We ran into some issues around connection keep-alive, so I made the following changes and am PR'ing them here in case you want to take them.

For the connection keep-alive and ping interval, I could imagine making that configurable - the current settings work for me though.

## mqtt: Change logging of ping to debug!() instead of info!()

Make ping-pong debug information, so that when running with INFO log
level, the logs aren't spammed with the same recurring message every 15
seconds.

## mqtt: Ping every 8 seconds instead of 15
I modified the temperature-client example to only send telemetry every
90 seconds, relying on the ping task to keep the connection alive. The
client got disconnected though and I figured out that the connection
keep-alive is set to 10 seconds, but the ping interval is every 15
seconds.

Increasing the ping interval to every 8 seconds appears to solve it.