### PR TITLE
Implement explicit ping handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,19 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["c2d-messages", "direct-methods", "twin-properties", "with-provision", "error-handling-messages"]
+default = [
+  "c2d-messages",
+  "direct-methods",
+  "twin-properties",
+  "with-provision",
+  "error-handling-messages",
+  "ping-response"
+]
 direct-methods = []
 twin-properties = []
 c2d-messages = []
 error-handling-messages = []
+ping-response = []
 https-transport = ["hyper", "hyper-tls"]
 with-provision = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,15 @@ default = [
   "twin-properties",
   "with-provision",
   "error-handling-messages",
-  "ping-response"
+  "ping-response",
+  "automatic-ping",
 ]
 direct-methods = []
 twin-properties = []
 c2d-messages = []
 error-handling-messages = []
 ping-response = []
+automatic-ping = []
 https-transport = ["hyper", "hyper-tls"]
 with-provision = []
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ async fn main() {
     )
     .unwrap();
 
-    let mut client = IoTHubClient::new(&hostname, device_id, token_source).await?;
+    let mut client = IoTHubClient::new(&hostname, device_id, None, token_source).await?;
 
     info!("Initialized client");
 

--- a/examples/receive-c2d-messages.rs
+++ b/examples/receive-c2d-messages.rs
@@ -15,7 +15,7 @@ async fn main() -> azure_iot_sdk::Result<()> {
     let token_source =
         DeviceKeyTokenSource::new(&hostname, &device_id, &shared_access_key).unwrap();
 
-    let mut client = IoTHubClient::new(&hostname, device_id, token_source).await?;
+    let mut client = IoTHubClient::new(&hostname, device_id, None, token_source).await?;
 
     info!("Initialized client");
 

--- a/examples/temperature-client.rs
+++ b/examples/temperature-client.rs
@@ -75,7 +75,7 @@ async fn main() -> azure_iot_sdk::Result<()> {
     let token_source =
         DeviceKeyTokenSource::new(&hostname, &device_id, &shared_access_key).unwrap();
 
-    let mut client = IoTHubClient::new(&hostname, device_id, token_source).await?;
+    let mut client = IoTHubClient::new(&hostname, device_id, None, token_source).await?;
 
     info!("Initialized client");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -77,7 +77,8 @@ impl IoTHubClient {
         TS: TokenSource + Send + Sync + Clone + 'static,
     {
         let transport =
-            ClientTransport::new(hub_name, device_id.clone(), model_id, token_source.clone()).await?;
+            ClientTransport::new(hub_name, device_id.clone(), model_id, token_source.clone())
+                .await?;
 
         Ok(Self {
             device_id,

--- a/src/client.rs
+++ b/src/client.rs
@@ -70,13 +70,14 @@ impl IoTHubClient {
     pub async fn new<TS>(
         hub_name: &str,
         device_id: String,
+        model_id: Option<String>,
         token_source: TS,
     ) -> crate::Result<IoTHubClient>
     where
         TS: TokenSource + Send + Sync + Clone + 'static,
     {
         let transport =
-            ClientTransport::new(hub_name, device_id.clone(), token_source.clone()).await?;
+            ClientTransport::new(hub_name, device_id.clone(), model_id, token_source.clone()).await?;
 
         Ok(Self {
             device_id,

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
     feature = "c2d-messages",
     feature = "twin-properties",
     feature = "error-handling-messages",
+    feature = "ping-response",
 ))]
 #[derive(Debug)]
 pub enum MessageType {
@@ -23,6 +24,9 @@ pub enum MessageType {
     /// Error occurred in the message loop
     #[cfg(feature = "error-handling-messages")]
     ErrorReceive(VariablePacketError),
+    /// Cloud responded to a ping
+    #[cfg(feature = "ping-response")]
+    PingResponse,
 }
 
 /// Instance to respond to a direct method invocation

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -19,6 +19,7 @@ use tokio::net::TcpStream;
 ))]
 use tokio::sync::mpsc::{channel, Receiver};
 use tokio::sync::Mutex;
+#[cfg(feature = "automatic-ping")]
 use tokio::{task::JoinHandle, time};
 use tokio_native_tls::{TlsConnector, TlsStream};
 
@@ -178,10 +179,12 @@ pub(crate) struct MqttTransport {
     device_id: String,
     #[cfg(feature = "c2d-messages")]
     rx_topic_prefix: String,
+    #[cfg(feature = "automatic-ping")]
     ping_join_handle: Option<Arc<JoinHandle<()>>>,
     // rx_loop_handle: Option<AbortHandle>,
 }
 
+#[cfg(feature = "automatic-ping")]
 impl Drop for MqttTransport {
     fn drop(&mut self) {
         // Check to see whether we're the last instance holding the Arc and only abort the ping if so
@@ -218,7 +221,7 @@ impl MqttTransport {
 
         let (read_socket, write_socket) = tokio::io::split(socket);
 
-        let mut mqtt_transport = Self {
+        let mqtt_transport = Self {
             token_source: Box::new(Arc::new(token_source)),
             write_socket: Arc::new(Mutex::new(write_socket)),
             read_socket: Arc::new(Mutex::new(read_socket)),
@@ -226,16 +229,23 @@ impl MqttTransport {
             device_id: device_id.to_string(),
             #[cfg(feature = "c2d-messages")]
             rx_topic_prefix: device_bound_messages_topic_prefix(&device_id),
+            #[cfg(feature = "automatic-ping")]
             ping_join_handle: None,
             // rx_loop_handle: None,
         };
 
-        mqtt_transport.ping_join_handle = Some(Arc::new(mqtt_transport.ping_on_secs_interval(8)));
+        #[cfg(feature = "automatic-ping")]
+        let mut mqtt_transport = mqtt_transport;
+        #[cfg(feature = "automatic-ping")]
+        {
+            mqtt_transport.ping_join_handle = Some(Arc::new(mqtt_transport.ping_on_secs_interval(8)));
+        }
 
         Ok(mqtt_transport)
     }
 
     ///
+    #[cfg(feature = "automatic-ping")]
     fn ping_on_secs_interval(&self, ping_interval: u8) -> JoinHandle<()> {
         let mut ping_interval = time::interval(time::Duration::from_secs(ping_interval.into()));
         let mut cloned_self = self.clone();

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -382,6 +382,10 @@ impl Transport for MqttTransport {
                     // TODO: handle ping req from server and we should send ping response in return
                     VariablePacket::PingrespPacket(..) => {
                         debug!("Receiving PINGRESP from broker ..");
+                        #[cfg(feature = "ping-response")]
+                        if handler_tx.send(MessageType::PingResponse).await.is_err() {
+                            break;
+                        };
                     }
                     VariablePacket::PublishPacket(ref publ) => {
                         let mut message = Message::new(publ.payload().to_vec());

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -208,7 +208,10 @@ impl MqttTransport {
     {
         // &model-id=dtmi:<string>;<version
         let user_name = if let Some(model_id) = model_id {
-            format!("{}/{}/?api-version=2020-09-30&model-id={}", hub_name, device_id, model_id)
+            format!(
+                "{}/{}/?api-version=2020-09-30&model-id={}",
+                hub_name, device_id, model_id
+            )
         } else {
             format!("{}/{}/?api-version=2020-09-30", hub_name, device_id)
         };
@@ -238,7 +241,8 @@ impl MqttTransport {
         let mut mqtt_transport = mqtt_transport;
         #[cfg(feature = "automatic-ping")]
         {
-            mqtt_transport.ping_join_handle = Some(Arc::new(mqtt_transport.ping_on_secs_interval(8)));
+            mqtt_transport.ping_join_handle =
+                Some(Arc::new(mqtt_transport.ping_on_secs_interval(8)));
         }
 
         Ok(mqtt_transport)

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -339,6 +339,7 @@ impl IoTHubClient {
         let client = IoTHubClient::new(
             &response.assigned_hub,
             response.device_id,
+            None,
             token_source.clone(),
         )
         .await?;

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -326,6 +326,7 @@ impl IoTHubClient {
         device_id: String,
         device_key: &str,
         max_retries: i32,
+        model_id: Option<String>,
     ) -> Result<IoTHubClient, Box<dyn std::error::Error>> {
         let response =
             get_iothub_from_provision_service(scope_id, &device_id, device_key, max_retries)
@@ -339,7 +340,7 @@ impl IoTHubClient {
         let client = IoTHubClient::new(
             &response.assigned_hub,
             response.device_id,
-            None,
+            model_id,
             token_source.clone(),
         )
         .await?;


### PR DESCRIPTION
Adds two features for explicit ping handling. A ping-response feature for adding a PingResponse message and a default feature automatic-pinging that adds the ping thread to the mqtt transport.

The motivation for this change is that we wanted better control over when to ping and how to react if the server did or did not respond. Specifically, we have a case where we seem to lose connection to the server and we want to detect that case by seeing if it responds to our pings.