### PR TITLE
Remove the `chrono` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "net", "io-util", "time", "sync"] }
 native-tls = "0.2.4"
 tokio-native-tls = "0.3"
-chrono = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
 base64 = "0.13"

--- a/src/mqtt_transport.rs
+++ b/src/mqtt_transport.rs
@@ -34,9 +34,10 @@ use crate::message::MessageType;
 #[cfg(feature = "direct-methods")]
 use crate::message::{DirectMethodInvocation, DirectMethodResponse};
 use crate::{token::{TokenSource, TokenProvider}, transport::Transport};
-use chrono::{Duration, Utc};
 use std::sync::Arc;
 use std::convert::From;
+use std::time::Duration;
+use std::time::SystemTime;
 
 // Incoming topic names
 #[cfg(feature = "direct-methods")]
@@ -203,8 +204,8 @@ impl MqttTransport {
     {
         let user_name = format!("{}/{}/?api-version=2018-06-30", hub_name, device_id);
 
-        let expiry = Utc::now() + Duration::days(1);
-        trace!("Generating token that will expire at {}", expiry);
+        let expiry = SystemTime::now() + Duration::from_secs(60 * 60 * 24);
+        trace!("Generating token that will expire at {:?}", expiry);
         let token = token_source.get(&expiry);
         trace!("Using token {}", token);
 


### PR DESCRIPTION
The `time` crate is the preferred crate nowadays with `chrono` having been unmaintained for a long time. Though as it turns out, this crate doesn't even need either crate as `std` provides all the functionality necessary here.