### PR TITLE
Concrete error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,4 +9,7 @@ pub enum IoTHubError {
     TlsError(#[from] native_tls::Error),
     #[error("{0}")]
     Other(String),
+    #[cfg(feature = "https-transport")]
+    #[error("{0}")]
+    HttpError(#[from] reqwest::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+///
+#[derive(Debug, Error)]
+pub enum IoTHubError {
+    #[error("")]
+    IoError(#[from] std::io::Error),
+    #[error("")]
+    TlsError(#[from] native_tls::Error),
+    #[error("{0}")]
+    Other(String),
+}

--- a/src/http_transport.rs
+++ b/src/http_transport.rs
@@ -7,7 +7,10 @@ use crate::message::Message;
     feature = "twin-properties"
 ))]
 use crate::message::MessageType;
-use crate::{token::{TokenProvider, TokenSource}, transport::Transport};
+use crate::{
+    token::{TokenProvider, TokenSource},
+    transport::Transport,
+};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use std::sync::Arc;
@@ -30,8 +33,7 @@ impl HttpsTransport {
         hub_name: &str,
         device_id: String,
         token_source: TokenProvider,
-    ) -> crate::Result<Self>
-    {
+    ) -> crate::Result<Self> {
         let transport = Self {
             hub_name: hub_name.to_string(),
             device_id,
@@ -97,20 +99,22 @@ impl Drop for HttpsTransport {
 impl Transport for HttpsTransport {
     ///
     async fn send_message(&mut self, message: Message) -> crate::Result<()> {
-        let req = self.client.post(format!(
-            "https://{}/devices/{}/messages/events?api-version=2019-03-30",
-            self.hub_name, self.device_id
-        ))
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(reqwest::header::AUTHORIZATION, self.get_token())
-        .body(message.body);
+        let req = self
+            .client
+            .post(format!(
+                "https://{}/devices/{}/messages/events?api-version=2019-03-30",
+                self.hub_name, self.device_id
+            ))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(reqwest::header::AUTHORIZATION, self.get_token())
+            .body(message.body);
 
         match req.send().await {
             Ok(res) => {
                 debug!("Response: {:?}", res);
                 Ok(())
             }
-            Err(err) => Err(Box::new(err)),
+            Err(err) => Err(crate::error::IoTHubError::HttpError(err)),
         }
     }
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub const SDK_VERSION: &str = std::env!("CARGO_PKG_VERSION");
 pub mod client;
 /// The IoT Hub client
 pub mod client_builder;
+pub mod error;
 pub use client::*;
 
 // #[cfg(feature = "http-transport")]
@@ -94,4 +95,4 @@ pub mod transport;
 pub mod provision;
 
 /// Convenience type alias for `std::result::Result<T, Box<dyn std::error::Error>>`
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T> = std::result::Result<T, crate::error::IoTHubError>;


### PR DESCRIPTION
- Implement error enum instead of Box dyn
- Use `thiserror` for making things easier